### PR TITLE
merge_documents_by_page to merge documents by file/page number

### DIFF
--- a/exercices/tp_4/1_gcs_to_cloudsql.ipynb
+++ b/exercices/tp_4/1_gcs_to_cloudsql.ipynb
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -183,7 +183,7 @@
    ],
    "source": [
     "# Specify the file path (replace with an actual file from your bucket)\n",
-    "file_path = 'data/1 - Gen AI - Dauphine Tunis.pptx'\n",
+    "file_path = \"data/1 - Gen AI - Dauphine Tunis.pptx\"\n",
     "\n",
     "# Get the blob object\n",
     "blob = bucket.get_blob(file_path)\n",
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -277,7 +277,7 @@
    ],
    "source": [
     "# Load all the\n",
-    "blobs = list(bucket.list_blobs(prefix='data/'))\n",
+    "blobs = list(bucket.list_blobs(prefix=\"data/\"))\n",
     "documents: list[Document] = []\n",
     "if blobs:\n",
     "    for blob in blobs:\n",
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3157,17 +3157,20 @@
     "    merged_documents: list[Document] = []\n",
     "    page_dict = {}\n",
     "\n",
-    "    # Group documents by page number\n",
+    "    # Group documents by file/page number\n",
     "    for doc in documents:\n",
+    "        document_source = doc.metadata.get(\"source\")\n",
     "        page_number = doc.metadata.get('page_number')\n",
-    "        if page_number is not None:\n",
-    "            if page_number not in page_dict:\n",
-    "                page_dict[page_number] = [doc]\n",
-    "            else:\n",
-    "                page_dict[page_number].append(doc)\n",
     "\n",
-    "    # Merge documents for each page\n",
-    "    for page_number, docs in page_dict.items():\n",
+    "        if page_number is not None and document_source is not None:\n",
+    "            key = (document_source, page_number)\n",
+    "            if key not in page_dict:\n",
+    "                page_dict[key] = [doc]\n",
+    "            else:\n",
+    "                page_dict[key].append(doc)\n",
+    "\n",
+    "    # Merge documents for each file/page\n",
+    "    for (document_source, page_number), docs in page_dict.items():\n",
     "        if docs:\n",
     "            # Use the metadata of the first document in the group\n",
     "            merged_metadata = docs[0].metadata\n",
@@ -3280,7 +3283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3296,32 +3299,34 @@
    ],
    "source": [
     "from dotenv import load_dotenv\n",
+    "\n",
     "load_dotenv()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "from config import PROJECT_ID, REGION, INSTANCE, DATABASE, DB_USER\n",
+    "\n",
     "DB_PASSWORD = os.environ[\"DB_PASSWORD\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "TABLE_NAME = \"fb_table\" # Table name in the database initials-table. Ex: fb_table"
+    "TABLE_NAME = \"fb_table\"  # Table name in the database initials-table. Ex: fb_table"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3335,12 +3340,12 @@
     "    database=DATABASE,\n",
     "    user=DB_USER,\n",
     "    password=DB_PASSWORD,\n",
-    ")\n"
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3357,7 +3362,7 @@
     "\n",
     "try:\n",
     "    await engine.ainit_vectorstore_table(\n",
-    "        table_name=TABLE_NAME, # Vector size for VertexAI model(textembedding-gecko@latest)\n",
+    "        table_name=TABLE_NAME,  # Vector size for VertexAI model(textembedding-gecko@latest)\n",
     "        vector_size=768,\n",
     "    )\n",
     "except ProgrammingError:\n",


### PR DESCRIPTION
The original method (when completed) would merge all the documents from different files with the same page number.
In the case of our TP for example, it would merge the 4 first pages from the 4 pptx together.
This Could lead to inaccuracies when searching for relevant documents later.

With this modification it would only merge documents issued from the same file.
Now, for the same example, each first page from each of the 4 pptx would be merged alone from the others.

See photos below (before and after):

<img width="952" alt="before" src="https://github.com/user-attachments/assets/b825719e-554a-410c-87c0-dfe812f27acd">

<img width="939" alt="after" src="https://github.com/user-attachments/assets/baee4a4b-09b1-4b36-ad77-1d418e5fb02e">



